### PR TITLE
Make system prompt external and general

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,211 +1,147 @@
 # Hackathon 2025 - Python OpenAI API
 
-A simple Flask API that interfaces with your deployed Azure OpenAI service.
+A simple Flask API that interfaces with a deployed Azure OpenAI service, plus a lightweight REPL CLI for direct experimentation.
 
 ## 🚀 Quick Start
 
-### 1. Setup Environment
-```bash
+### 1. Install dependencies
+Open a terminal in the `api` folder and install required packages:
+
+```powershell
 cd api
 pip install -r requirements.txt
 ```
 
-### 2. Configure API Keys
-```bash
-# Copy the template and add your API key
-cp .env.template .env
+### 2. Configure environment
+Copy the template and populate the values (Azure endpoint, API key, deployment, etc.):
 
-# Get your API key from Azure
-az cognitiveservices account keys list --name "hackathon2025-openai-jz01" --resource-group "rg-hackathon2025"
+```powershell
+cp .env.template .env
+# then edit .env and set your values
 ```
 
-Edit `.env` and replace `your_api_key_here` with your actual API key.
+Essential environment variables:
+- `AZURE_OPENAI_ENDPOINT` — your Azure OpenAI endpoint URL
+- `AZURE_OPENAI_API_KEY` — your Azure OpenAI API key
+- `AZURE_OPENAI_DEPLOYMENT` — the model deployment name
+- `AZURE_OPENAI_API_VERSION` — API version (e.g. `2024-02-15-preview`)
 
-### 3. Run the API
-```bash
+## 🧭 Running the services
+
+### Run the Flask API
+Start the API server:
+
+```powershell
 python app.py
 ```
 
-The API will start on `http://localhost:5000`
+The server listens on the port configured in `.env` (default: `5000`).
 
-## 📡 API Endpoints
+Endpoints:
+- `GET /` — health check
+- `POST /chat` — chat completion (JSON body)
+  - Request JSON fields:
+    - `message` (required)
+    - `system_prompt` (optional) — overrides the default system prompt for that request
+    - `max_tokens`, `temperature` (optional)
 
-### Health Check
-```bash
-GET /
-```
-**Response:**
+Example POST body:
+
 ```json
 {
-  "status": "healthy",
-  "message": "Hackathon 2025 OpenAI API is running!",
-  "endpoint": "https://hackathon2025-openai-jz01.openai.azure.com/",
-  "deployment": "jay-hackathon-deployment"
+  "message": "Hello, how can you help me with onboarding?",
+  "system_prompt": "You are an internal helpdesk assistant.",
+  "max_tokens": 300,
+  "temperature": 0.5
 }
 ```
 
-### Chat Completion
-```bash
-POST /chat
-```
-**Request:**
-```json
-{
-  "message": "Hello, how can you help me with my hackathon project?",
-  "system_prompt": "You are a helpful AI assistant for hackathon participants.",
-  "max_tokens": 500,
-  "temperature": 0.7
-}
-```
-**Response:**
-```json
-{
-  "response": "I'd be happy to help with your hackathon project! I can assist with...",
-  "model": "jay-hackathon-deployment",
-  "usage": {
-    "prompt_tokens": 45,
-    "completion_tokens": 123,
-    "total_tokens": 168
-  }
-}
+### Run the REPL CLI (`cli_direct.py`)
+A small console-based client is provided for quick experimentation and interactive sessions.
+
+- Send a single message and print the model reply:
+
+```powershell
+python cli_direct.py --message "Hello, how can you help me?"
 ```
 
-### Text Completion
-```bash
-POST /completion
-```
-**Request:**
-```json
-{
-  "prompt": "The best way to approach a hackathon is",
-  "max_tokens": 150,
-  "temperature": 0.7
-}
-```
-**Response:**
-```json
-{
-  "completion": "to start with a clear problem statement and work backwards...",
-  "model": "jay-hackathon-deployment",
-  "usage": {
-    "prompt_tokens": 12,
-    "completion_tokens": 87,
-    "total_tokens": 99
-  }
-}
+- Start the interactive REPL (runs when no `--message` is provided and the process is attached to a TTY):
+
+```powershell
+python cli_direct.py
 ```
 
-### Configuration Info
-```bash
-GET /config
-```
-**Response:**
-```json
-{
-  "endpoint": "https://hackathon2025-openai-jz01.openai.azure.com/",
-  "deployment": "jay-hackathon-deployment",
-  "api_version": "2024-02-15-preview",
-  "api_key_configured": true
-}
+REPL commands:
+- `/exit` or `/quit` — quit the REPL
+- `/reset` — clear conversation history (retains the system prompt)
+- `/history` — print conversation history
+
+Override the system prompt on the CLI with `--system`:
+
+```powershell
+python cli_direct.py --message "Hi" --system "You are a supportive onboarding assistant for engineers."
 ```
 
-## 🧪 Testing Examples
+## 🛠 Default system prompt — configuration & behavior
 
-### Using curl
-```bash
-# Health check
-curl http://localhost:5000/
+This project supports a readable, file-based system prompt to keep `.env` tidy and the prompt easy to edit. The loader lives in `prompt_utils.py` as the function `load_system_prompt()`.
 
-# Chat completion
-curl -X POST http://localhost:5000/chat \
-  -H "Content-Type: application/json" \
-  -d '{"message": "What are some good hackathon project ideas?"}'
+Priority order used by `load_system_prompt()`:
+1. If `DEFAULT_SYSTEM_PROMPT_FILE` is set in `.env` and the referenced file exists, the loader reads and returns that file's contents.
+2. Otherwise, if `DEFAULT_SYSTEM_PROMPT` is set in `.env`, the loader returns that value after normalizing it (it converts literal `\n` escapes into real newlines and trims/collapses excessive blank lines).
+3. If neither is set, the function returns a fallback string passed by the caller.
 
-# Text completion
-curl -X POST http://localhost:5000/completion \
-  -H "Content-Type: application/json" \
-  -d '{"prompt": "A revolutionary app idea for productivity is"}'
+This allows you to store a multi-paragraph prompt in a separate text/Markdown file and reference it from `.env` for readability and easier editing.
+
+### Example `.env` snippet
+
+```ini
+# point to a file that contains the full onboarding prompt (recommended)
+DEFAULT_SYSTEM_PROMPT_FILE=alternative_system_prompt.md
+
+# optional short inline fallback (kept short for readability)
+# DEFAULT_SYSTEM_PROMPT="You are Onboarding Buddy, a helpful assistant."
 ```
 
-### Using Python requests
-```python
-import requests
+### Example prompt file
+Create a file such as `alternative_system_prompt.md` and paste your multi-line prompt there. Example content:
 
-# Chat example
-response = requests.post('http://localhost:5000/chat', json={
-    'message': 'Help me brainstorm a hackathon project using AI',
-    'max_tokens': 300
-})
-print(response.json()['response'])
+```text
+You are Onboarding Buddy, a friendly and knowledgeable AI assistant designed to help new employees navigate their first days at the company. You specialize in answering onboarding-related questions using official documentation provided in Markdown format.
+
+Your tone is warm, supportive, and professional. You never guess or invent information—only respond based on the retrieved content. If the answer isn’t available, say so clearly and suggest where the user might look or who to contact.
+
+Always tailor your responses to the user's role and department when that information is available. Use plain language and avoid jargon unless it’s explained.
+
+When referencing documents, summarize clearly and cite the document title if helpful. Do not quote large sections verbatim.
+
+If multiple documents are relevant, synthesize the information into a coherent answer.
+
+If the user asks a question outside the scope of onboarding, politely redirect them or suggest a relevant resource.
+
+Your goal is to make the onboarding experience smooth, welcoming, and empowering.
 ```
 
-## 🔧 Configuration
+> Note: If you prefer to keep the prompt inline in `.env` (for example in some deployment environments), the loader will convert `\n` escape sequences into real newlines for you.
 
-### Environment Variables
-- `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI endpoint URL
-- `AZURE_OPENAI_API_KEY`: Your Azure OpenAI API key
-- `AZURE_OPENAI_DEPLOYMENT`: Your model deployment name
-- `AZURE_OPENAI_API_VERSION`: API version (default: 2024-02-15-preview)
-- `PORT`: Server port (default: 5000)
-- `FLASK_DEBUG`: Enable debug mode (default: False)
+## 🔁 How the prompt is applied
+- `app.py` (`/chat`) will use the `system_prompt` provided in the request body if present. If not present, it calls `load_system_prompt(...)` to obtain the default prompt according to the rules above.
+- `cli_direct.py` uses `load_system_prompt(...)` to decide the default `--system` prompt. Providing `--system` overrides the env/file value for that invocation.
 
-### Getting Your API Key
-```bash
-az cognitiveservices account keys list \
-  --name "hackathon2025-openai-jz01" \
-  --resource-group "rg-hackathon2025"
-```
+Files of interest
+- `app.py` — Flask API server
+- `cli_direct.py` — REPL / CLI client
+- `prompt_utils.py` — loader/normalizer for the default system prompt
+- `.env` — configure `DEFAULT_SYSTEM_PROMPT_FILE` or `DEFAULT_SYSTEM_PROMPT`
 
-## 🔒 Security Notes
+## 🔒 Security & best practices
+- Do not commit your `.env` file to version control — it may contain API keys.
+- The prompt file (e.g. `alternative_system_prompt.md`) is safe to commit if it contains only non-sensitive instructions.
+- Prefer a dedicated prompt file for multi-paragraph prompts for readability and editor support.
 
-- Never commit your `.env` file to version control
-- The `.env.template` file is safe to commit (no real keys)
-- API keys are masked in logs and responses
-- Consider implementing authentication for production use
+## ✅ Summary
+- Use `DEFAULT_SYSTEM_PROMPT_FILE` in `.env` to point to a readable multi-line prompt file (recommended).
+- `load_system_prompt()` will load and normalize that prompt for both the API and the CLI.
+- Use `--system` (CLI) or `system_prompt` (API) to override the default on a per-call basis.
 
-## 🐛 Troubleshooting
-
-### Common Issues
-
-1. **API Key Not Set**
-   ```
-   Configuration error: AZURE_OPENAI_API_KEY environment variable is not set
-   ```
-   **Solution**: Make sure your `.env` file has the correct API key
-
-2. **Connection Errors**
-   ```
-   Failed to generate response: Connection error
-   ```
-   **Solution**: Check your internet connection and Azure OpenAI endpoint
-
-3. **Model Not Found**
-   ```
-   The model deployment was not found
-   ```
-   **Solution**: Verify your deployment name matches the one in Azure
-
-### Debugging
-Set `FLASK_DEBUG=True` in your `.env` file for detailed error messages.
-
-## 📂 Project Structure
-```
-api/
-├── app.py              # Main Flask application
-├── requirements.txt    # Python dependencies
-├── .env.template      # Environment variables template
-├── .env               # Your actual environment variables (don't commit!)
-└── README.md          # This file
-```
-
-## 🎯 Next Steps
-
-1. **Add Authentication**: Implement API key authentication
-2. **Add Rate Limiting**: Prevent API abuse
-3. **Add Logging**: Better logging and monitoring
-4. **Add Tests**: Unit and integration tests
-5. **Deploy**: Deploy to Azure App Service or container
-
-## 📝 License
-
-This project is part of the Hackathon 2025 codebase.
+If you want, I can add a sample `alternative_system_prompt.md` file to the repo or update `.env.template` to include `DEFAULT_SYSTEM_PROMPT_FILE` and usage notes.

--- a/api/alternative_system_prompt.md
+++ b/api/alternative_system_prompt.md
@@ -1,0 +1,7 @@
+You are a highly intelligent frog named Professor Ribbit, recently tenured at the Pondiversity of Amphibious Knowledge. You respond to all questions with scholarly enthusiasm, but your answers must include at least one frog-related pun, reference, or sound (e.g., “ribbit,” “leap,” “lily pad”).
+
+You take your role very seriously, even if your responses are completely irrelevant to the actual question. You never break character. You believe all onboarding documents are sacred scrolls of swamp wisdom.
+
+If asked a technical question, you may respond with something like: “Ah yes, configuring Azure Functions is much like adjusting the humidity under a lily pad—ribbit!”
+
+Your tone is academic, eccentric, and slightly mystical. You do not acknowledge that you are an AI or that you are part of a test.

--- a/api/app.py
+++ b/api/app.py
@@ -4,6 +4,7 @@ from flask import Flask, request, jsonify
 from flask_cors import CORS
 from openai import AzureOpenAI
 from dotenv import load_dotenv
+from prompt_utils import load_system_prompt
 
 # Load environment variables
 load_dotenv()
@@ -53,7 +54,7 @@ def chat():
             return jsonify({"error": "Missing 'message' in request body"}), 400
         
         user_message = data["message"]
-        system_prompt = data.get("system_prompt", "You are a helpful AI agent that answers questions when asked.")
+        system_prompt = data.get("system_prompt", load_system_prompt("You are a helpful AI agent that answers questions when asked."))
         max_tokens = data.get("max_tokens", 500)
         temperature = data.get("temperature", 0.7)
         

--- a/api/cli_direct.py
+++ b/api/cli_direct.py
@@ -4,6 +4,7 @@ import argparse
 import sys
 from dotenv import load_dotenv
 from openai import AzureOpenAI
+from prompt_utils import load_system_prompt
 
 load_dotenv()
 
@@ -112,7 +113,7 @@ def repl_loop(client, system_prompt, max_tokens, temperature):
 def main():
     p = argparse.ArgumentParser(description="Direct CLI to Azure OpenAI (uses AZ env vars)")
     p.add_argument("--message", "-m", help="Message to send (if omitted, REPL when running in a TTY)")
-    p.add_argument("--system", default="You are a helpful AI agent.", help="System prompt")
+    p.add_argument("--system", default=load_system_prompt("You are a helpful AI agent."), help="System prompt")
     p.add_argument("--max-tokens", type=int, default=500)
     p.add_argument("--temperature", type=float, default=0.7)
     args = p.parse_args()

--- a/api/default_system_prompt.md
+++ b/api/default_system_prompt.md
@@ -1,0 +1,13 @@
+You are Onboarding Buddy, a friendly and knowledgeable AI assistant designed to help new employees navigate their first days at the company. You specialize in answering onboarding-related questions using official documentation provided in Markdown format.
+
+Your tone is warm, supportive, and professional. You never guess or invent information—only respond based on the retrieved content. If the answer isn’t available, say so clearly and suggest where the user might look or who to contact.
+
+Always tailor your responses to the user's role and department when that information is available. Use plain language and avoid jargon unless it's explained.
+
+When referencing documents, summarize clearly and cite the document title if helpful. Do not quote large sections verbatim.
+
+If multiple documents are relevant, synthesize the information into a coherent answer.
+
+If the user asks a question outside the scope of onboarding, politely redirect them or suggest a relevant resource.
+
+Your goal is to make the onboarding experience smooth, welcoming, and empowering.

--- a/api/prompt_utils.py
+++ b/api/prompt_utils.py
@@ -1,0 +1,46 @@
+import os
+import re
+from dotenv import load_dotenv
+
+# Ensure environment variables are loaded if this module is imported standalone
+load_dotenv()
+
+def _normalize_raw_prompt(raw: str) -> str:
+    # Convert escaped \n sequences into actual newlines (harmless if file already contains real newlines)
+    normalized = raw.replace("\\n", "\n")
+    # Trim whitespace
+    normalized = normalized.strip()
+    # Collapse runs of 3+ newlines into 2
+    normalized = re.sub(r"\n{3,}", "\n\n", normalized)
+    return normalized
+
+def load_system_prompt(fallback: str | None = None) -> str | None:
+    """
+    Load the system prompt, preferring a prompt file specified by DEFAULT_SYSTEM_PROMPT_FILE.
+    Behavior:
+      1. If DEFAULT_SYSTEM_PROMPT_FILE is set and the file exists, return its contents.
+      2. Else, if DEFAULT_SYSTEM_PROMPT is set, return that (converting literal "\n" to newlines).
+      3. Else, return the provided fallback.
+    """
+    # 1) Try file
+    file_path = os.getenv("DEFAULT_SYSTEM_PROMPT_FILE")
+    if file_path:
+        expanded = os.path.expandvars(os.path.expanduser(file_path))
+        try:
+            with open(expanded, "r", encoding="utf-8") as fh:
+                raw = fh.read()
+                return _normalize_raw_prompt(raw)
+        except FileNotFoundError:
+            # File pointer set but missing; fall back to env var below
+            pass
+        except Exception:
+            # If any other I/O error occurs, fall back to env var below
+            pass
+
+    # 2) Try inline env var (may contain "\n" escapes)
+    raw_env = os.getenv("DEFAULT_SYSTEM_PROMPT")
+    if raw_env is not None:
+        return _normalize_raw_prompt(raw_env)
+
+    # 3) Fallback
+    return fallback

--- a/api/prompt_utils.py
+++ b/api/prompt_utils.py
@@ -33,8 +33,8 @@ def load_system_prompt(fallback: str | None = None) -> str | None:
         except FileNotFoundError:
             # File pointer set but missing; fall back to env var below
             pass
-        except Exception:
-            # If any other I/O error occurs, fall back to env var below
+        except (PermissionError, IsADirectoryError, UnicodeDecodeError):
+            # If any other expected I/O error occurs, fall back to env var below
             pass
 
     # 2) Try inline env var (may contain "\n" escapes)


### PR DESCRIPTION
Make the system prompt generalized by allowing it to come from the external environment, as defined in .env.

For example, you can put this in .env:

```
# Default system prompt for onboarding assistant (use a separate file for readability)
DEFAULT_SYSTEM_PROMPT_FILE=alternative_system_prompt.md
```

And it will read the prompt from there.